### PR TITLE
Fix validation partial include typo

### DIFF
--- a/Views/Team/Create.cshtml
+++ b/Views/Team/Create.cshtml
@@ -11,6 +11,6 @@
 
 @section Scripts {
     @{
-        await Html.RenderPartialAsync("_ValidationScriptspartial");
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
     }
 }


### PR DESCRIPTION
## Summary
- fix validation script reference in `Create.cshtml`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684066ca146c83298efd3e1f1f148761