### PR TITLE
Validate Tournament date range

### DIFF
--- a/Models/TournamentModel.cs
+++ b/Models/TournamentModel.cs
@@ -1,13 +1,26 @@
 ﻿using MongoDB.Bson;
+using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
+using System;
 
 namespace basketball_tournament_tracker.Models
 {
-    public class Tournament
+    public class Tournament : IValidatableObject
     {
         public ObjectId Id { get; set; }
         public string Name { get; set; }
         public DateTime StartDate { get; set; }
         public DateTime EndDate { get; set; }
         public List<Team> Teams { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (EndDate < StartDate)
+            {
+                yield return new ValidationResult(
+                    "End date must be on or after the start date.",
+                    new[] { nameof(EndDate) });
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- enforce StartDate is not after EndDate in Tournament model

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684066d356388329ad0a76879313a7c3